### PR TITLE
Use OS agnostic Process.Signal instead of syscall.Kill to shutdown server

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 
-	"syscall"
 	"time"
 
 	"github.com/pkg/errors"
@@ -102,17 +101,7 @@ func (c *client) receive(sc chat.Chat_StreamClient) error {
 		case *chat.StreamResponse_ServerShutdown:
 			ServerLogf(ts, "the server is shutting down")
 			c.Shutdown = true
-
-			p, err := os.FindProcess(os.Getpid())
-			if err != nil {
-				ClientLogf(ts, "not able to find client process to shutdown: %v", err)
-			}
-
-			err = p.Signal(syscall.SIGTERM)
-			if err != nil {
-				ClientLogf(ts, "not able to shutdown client, forcing kill: %v", err)
-				p.Kill()
-			}
+			return nil
 		default:
 			ClientLogf(ts, "unexpected event from the server: %T", evt)
 			return nil

--- a/client.go
+++ b/client.go
@@ -105,7 +105,7 @@ func (c *client) receive(sc chat.Chat_StreamClient) error {
 
 			p, err := os.FindProcess(os.Getpid())
 			if err != nil {
-				panic(err)
+				ClientLogf(ts, "not able to find server process to shutdown: %v", err)
 			}
 
 			if runtime.GOOS == "windows" {

--- a/client.go
+++ b/client.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"io"
 	"os"
-	"runtime"
+
 	"syscall"
 	"time"
 
@@ -105,14 +105,13 @@ func (c *client) receive(sc chat.Chat_StreamClient) error {
 
 			p, err := os.FindProcess(os.Getpid())
 			if err != nil {
-				ClientLogf(ts, "not able to find server process to shutdown: %v", err)
+				ClientLogf(ts, "not able to find client process to shutdown: %v", err)
 			}
 
-			if runtime.GOOS == "windows" {
-				_ = p.Signal(os.Kill)
+			err = p.Signal(syscall.SIGKILL)
+			if err != nil {
+				ClientLogf(ts, "not able to shutdown client: %v", err)
 			}
-
-			_ = p.Signal(syscall.SIGTERM)
 		default:
 			ClientLogf(ts, "unexpected event from the server: %T", evt)
 			return nil

--- a/client.go
+++ b/client.go
@@ -108,9 +108,10 @@ func (c *client) receive(sc chat.Chat_StreamClient) error {
 				ClientLogf(ts, "not able to find client process to shutdown: %v", err)
 			}
 
-			err = p.Signal(syscall.SIGKILL)
+			err = p.Signal(syscall.SIGTERM)
 			if err != nil {
-				ClientLogf(ts, "not able to shutdown client: %v", err)
+				ClientLogf(ts, "not able to shutdown client, forcing kill: %v", err)
+				p.Kill()
 			}
 		default:
 			ClientLogf(ts, "unexpected event from the server: %T", evt)


### PR DESCRIPTION
Currently this is not compiling in Windows:

```
undefined: syscall.Kill
```

If we check the [docs for the `syscall` package](https://golang.org/pkg/syscall/) this is not recommended to be used directly:

> The primary use of syscall is inside other packages that provide a more portable interface to the system, such as "os", "time" and "net". Use those packages rather than this one if you can.

For my change I used `os.Kill` exclusively for Windows since terminations aren't handled by default and [interruptions aren't implemented](https://golang.org/pkg/os/#Process.Signal) and consequently the process will not terminate.